### PR TITLE
Change docs link to point to docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Rust library for zero-allocation parsing of binary data.
 
 Requires Rust version 1.6 or later (requires stable libcore for no_std).
 
-See [docs](src/lib.rs) for more information.
+See [docs](https://docs.rs/zero/) for more information.
 
 Available on [crates.io](https://crates.io/crates/zero/).
 


### PR DESCRIPTION
These docs are nicer than reading the source: https://docs.rs/zero/0.1.2/zero/